### PR TITLE
S3 unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ node_js:
   - "4.1"
   - "4.0"
 sudo: false
+before_script:
+  - "sudo apt-get update && sudo apt-get install ruby-full && gem install fakes3"
+  - "fakes3 -r /tmp/fakes3 -p 4567 &"
 script: "npm test"
+sudo: requires

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "test": "./node_modules/mocha/bin/mocha test --reporter spec"
   },
   "devDependencies": {
+    "mkdirp": "0.5.1",
     "mocha": "^2.3.4",
     "randomstring": "^1.1.3"
   }

--- a/test/before_script.sh
+++ b/test/before_script.sh
@@ -1,0 +1,3 @@
+apt-get install ruby-full
+gem install fakes3
+fakes3 -r /tmp/fakes3 -p 4567

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,99 @@
+var async = require('async');
+var fs = require('fs');
+var path = require('path');
+var randomstring = require('randomstring');
+var mkdirp = require('mkdirp');
+
+var rootDir = './testData';
+var backupFilesDir = path.join(rootDir,'dummyData');
+module.exports = {
+  logger: {
+    'error': function() {},
+    'log': function() {},
+    'info': function() {}
+  },
+  generateFiles: function(topTotal,done) {
+    var files = [];
+    var directories = [];
+
+    var makeFiles = function(dir,n) {
+      if (n > 0) {
+        for(var i=0; i<n; i++) {
+          files.push(path.join(dir,randomstring.generate()));
+          var newDirName = path.join(dir,randomstring.generate());
+          directories.push(newDirName);
+          makeFiles(newDirName,n-1);
+        }
+      }
+    }
+    makeFiles('',topTotal);
+
+    async.waterfall([
+      function(callback) {
+        mkdirp(backupFilesDir, function() {
+          callback();
+        });
+      },
+      function(callback) {
+        async.waterfall(
+          directories.map(function(dir) {
+            return function(innerCallback) {
+              fs.mkdir(path.join(backupFilesDir,dir),function(err) {
+                innerCallback(err);
+              });
+            };
+          }),
+          callback
+        );
+      },
+      function(callback) {
+        async.parallel(
+          files.map(function(file) {
+            return function(innerCallback) {
+              var data = randomstring.generate();;
+              fs.writeFile(path.join(backupFilesDir,file),data,function(err) {
+                innerCallback(err);
+              });
+            };
+          }),
+          callback
+        );
+      }
+    ],function(err) {
+      done(err,files);
+    });
+  },
+  removeFolder: removeFolder
+
+};
+
+function removeFolder(location,done) {
+  fs.readdir(location,function(err,files) {
+    async.each(files,function(file,callback) {
+      var filePath = path.join(location,file);
+      fs.stat(filePath,function(err,stat) {
+        if (err) {
+          callback(err);
+        } else if (stat.isDirectory()) {
+          removeFolder(filePath,callback);
+        } else {
+          fs.unlink(filePath,function (err) {
+            if (err) {
+              callback(err);
+            } else {
+              callback();
+            }
+          });
+        }
+      });
+    },function (err) {
+      if (err) {
+        done(err);
+      } else {
+        fs.rmdir(location,function(err) {
+          done(err);
+        });
+      }
+    });
+  });
+}

--- a/test/s3.js
+++ b/test/s3.js
@@ -1,0 +1,120 @@
+// Module requires
+var assert = require('assert');
+var async = require('async');
+var AWS = require('aws-sdk');
+var FileQueue = require('filequeue');
+var fs = require('fs');
+var path = require('path');
+
+// Classes
+var Database = require('./../lib/database');
+var S3Backuper = require('./../lib/backupers/s3Backuper');
+var BackupAgent = require('./../lib/backupAgent');
+
+
+// Local variables
+var helpers = require('./helpers/index');
+var rootDir = './testData';
+var backupFilesDir = path.join(rootDir,'dummyData');
+
+
+var config = {
+  'backupDirs': [
+    backupFilesDir
+  ],
+  'ignore': [
+    'ignoreThisFile',
+    '*.someExtension'
+  ],
+  'backupManifestFile': path.join(rootDir,'backupfiles.sqlite3'),
+  'aws': {
+    accessKeyId: '',
+    secretAccessKey: ''
+  }
+};
+
+describe('Backupers',function() {
+  describe('s3Backuper',function() {
+    var backuper;
+    var database;
+    var files;
+    var touchedFiles = [];
+    var s3;
+    config.aws.accessKeyId = "dsdsfdsfdsfdfs";
+    config.aws.secretAccessKey = "fsdfsfdfdssdffsd";
+    config.aws.s3ForcePathStyle = true; // Required for mac testing on fakes3
+    config.aws.endpoint = new AWS.Endpoint('http://localhost:4567');
+    config.s3BucketName = "testBucket";
+    AWS.config.update(config.aws);
+    s3 = new AWS.S3(config.aws);
+    before(function(done) {
+      async.waterfall([
+        function(callback) {
+          helpers.generateFiles(5,function(err, madeFiles) {
+            if (err) {
+              callback(err);
+            } else {
+              files = madeFiles;
+              callback();
+            }
+          });
+        },
+        function(callback) {
+          database = {
+            'touchFile': function(absPath,fsModifiedTime,size,callback) {
+              callback(null,touchedFiles.indexOf(absPath) >= 0);
+            }
+          };
+          touchedFiles = files
+            .filter(function(item,i) {
+              return i % 2 == 0;
+            })
+            .map(function(file) {
+              return path.join(backupFilesDir,file)
+            });
+          callback();
+        },
+        function(callback) {
+          var params = {
+            Bucket: 'testBucket',
+            ACL: 'private',
+            CreateBucketConfiguration: {
+              LocationConstraint: 'us-east-1'
+            },
+            GrantFullControl: "yes"
+          };
+          s3.createBucket(params, function(err, msg) {
+            callback();
+          });
+        }
+      ], done);
+
+      backuper = new S3Backuper(config, database,helpers.logger, new FileQueue(100));
+    });
+
+    it('should be able to upload a file to S3 vis upload function', function(done) {
+      this.timeout(6000);
+      var obj = {
+        'path': backupFilesDir + "/" + files[0]
+      };
+
+      obj.stat = fs.statSync(obj.path);
+      backuper.sendFile(obj, function(err, data) {
+        assert.equal(err, null);
+        s3.headObject({
+          Bucket: 'testBucket',
+          Key: obj.path
+        }, function (err, data) {
+          assert.equal(data.ContentLength, obj.stat.size);
+          done();
+        });
+      });
+    });
+
+    after(function(done) {
+      helpers.removeFolder(rootDir, done);
+    });
+  });
+});
+
+

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,10 @@
 var assert = require('assert');
 var fs = require('fs');
+
 var randomstring = require('randomstring');
-var BackupAgent = require('./lib/backupAgent');
+var BackupAgent = require('./../lib/backupAgent');
 var FileQueue = require('filequeue');
-var Database = require('./lib/database');
+var Database = require('./../lib/database');
 var path = require('path');
 var async = require('async');
 


### PR DESCRIPTION
I have added fakeS3 server and restructured unit tests so that we can more easily add future providers and improve code reusability.

Please note I want to extend the usage of helpers as theres a lot of repeat code between s3 unit tests and the main unit tests, but I did not want to create any conflicts with any code you have been working on.